### PR TITLE
Add additional output if noise_model

### DIFF
--- a/src/qibo_comb_optimisation/optimisation_class/optimisation_class.py
+++ b/src/qibo_comb_optimisation/optimisation_class/optimisation_class.py
@@ -310,9 +310,7 @@ class QUBO:
                     f_value += self.Qdict[(i, i)]
                 for j in range(i + 1, self.n):
                     if x[j] != 0:
-                        f_value += self.Qdict.get((i, j), 0) + self.Qdict.get(
-                            (j, i), 0
-                        )
+                        f_value += self.Qdict.get((i, j), 0) + self.Qdict.get((j, i), 0)
         return f_value
 
     def evaluate_grad_f(self, x):
@@ -694,14 +692,23 @@ class QUBO:
             alphas=optimised_alphas,
             custom_mixer=custom_mixer,
         )
+        original_circuit = Circuit.copy(circuit)
         if noise_model is not None:
             circuit = noise_model.apply(circuit)
-        # print("Final circuit:\n")
-        # print(circuit)
 
         result = backend.execute_circuit(circuit, nshots=nshots)
 
-        return best, params, extra, circuit, result.frequencies(binary=True)
+        if noise_model is not None:
+            return (
+                best,
+                params,
+                extra,
+                circuit,
+                result.frequencies(binary=True),
+                original_circuit,
+            )
+        else:
+            return best, params, extra, circuit, result.frequencies(binary=True)
 
     def qubo_to_qaoa_object(self, params: list = None):
         """


### PR DESCRIPTION
Without any noise model, the original circuit can be converted to OpenQASM string. 
In an external script, we can then save the OpenQASM string for future use.

However, when noise model is present, the original circuit will have noise channels implemented.
Certain noise channels cannot be converted to OpenQASM string, and thus the circuit that is returned cannot be saved for future use.

In this improved code, we simply change the outputs:

- if noise model is present, then we make a copy of the circuit before noise model is applied to send as additional output.
- if noise model is not present, then the functionality remains the same as before. 